### PR TITLE
Add date and time in PDF filename

### DIFF
--- a/api.py
+++ b/api.py
@@ -86,7 +86,7 @@ Le {day}/{month}/{year}  à {hour}:{minute}
 Signature : {args.prenom} {args.nom}
 '''
 
-    file_name = os.path.join('/tmp', f'attestation-{uuid.uuid1()}.pdf')
+    file_name = os.path.join('/tmp', f'attestation-{day}{month}-{hour}h{minute}_{uuid.uuid1()}.pdf')
     pdf = FPDF()
     pdf.add_page()
     pdf.add_font('DejaVu', '', 'DejaVuSansCondensed.ttf', uni=True)


### PR DESCRIPTION
When you have multiple attestations on your desk or phone, it is easier to find it when date and time is on filename.